### PR TITLE
DO not create primary index explicitly

### DIFF
--- a/dynamo_query/dynamo_table.py
+++ b/dynamo_query/dynamo_table.py
@@ -312,7 +312,6 @@ class DynamoTable(Generic[_RecordType], LazyLogger, ABC):
         attribute_definitions: List[AttributeDefinitionTypeDef] = []
         attribute_names: Set[str] = set()
         indexes = (
-            self.primary_index,
             *self.global_secondary_indexes,
             *self.local_secondary_indexes,
         )


### PR DESCRIPTION
## Public API changes

### Fixed

- `DataTable.primary_index` is no longer created explicitly
