### PR TITLE
Add missing keys to batch_get and batch_delete methods

### DIFF
--- a/dynamo_query/dynamo_table.py
+++ b/dynamo_query/dynamo_table.py
@@ -523,7 +523,8 @@ class DynamoTable(Generic[_RecordType], LazyLogger, ABC):
         for record in data_table.get_records():
             record = self._convert_record(record)
             record = self.normalize_record(record)
-            get_data_table.add_record(self._get_record_keys(record))
+            record.update(self._get_record_keys(record))
+            get_data_table.add_record(record)
 
         results = (
             self.dynamo_query_class.build_batch_get_item(logger=self._logger)
@@ -632,7 +633,8 @@ class DynamoTable(Generic[_RecordType], LazyLogger, ABC):
         for record in data_table.get_records():
             record = self._convert_record(record)
             record = self.normalize_record(record)
-            delete_data_table.add_record(self._get_record_keys(record))
+            record.update(self._get_record_keys(record))
+            delete_data_table.add_record(record)
 
         results = (
             self.dynamo_query_class.build_batch_delete_item(logger=self._logger)


### PR DESCRIPTION
## Public API changes

### Fixed

- Fix missing required record keys error on internal `batch_get` usage
