### PR TITLE
Update DataTable.drop_duplicates to ignore case in column names

### DIFF
--- a/dynamo_query/data_table.py
+++ b/dynamo_query/data_table.py
@@ -756,10 +756,14 @@ class DataTable(Generic[_RecordType], dict):
         else:
             subset = columns
 
+        subset = [x.lower() for x in subset]
+
         hashed_val_set: Set[int] = set()
         result = self.__class__({key: [] for key in self.keys()}, record_class=self.record_class)
         for record in self.get_records():
-            hashed_val = hash(str([value for key, value in record.items() if key in subset]))
+            hashed_val = hash(
+                str([value for key, value in record.items() if key.lower() in subset])
+            )
 
             if hashed_val not in hashed_val_set:
                 hashed_val_set.add(hashed_val)

--- a/tests/test_data_table.py
+++ b/tests/test_data_table.py
@@ -339,7 +339,7 @@ class TestDataTable:
 
         # it should throw an error as the column name provied is invalid
         with pytest.raises(DataTableError):
-            _ = data_table.drop_duplicates(subset=("invalid_column", ))
+            _ = data_table.drop_duplicates(subset=("invalid_column",))
 
         # not normalized table
         data_table = DataTable(


### PR DESCRIPTION
## Public API changes

### Changed

- Ignore case in column names match in `DataTable.drop_duplicates`