### PR TITLE
Create table pay per request

### DIFF
--- a/dynamo_query/dynamo_table.py
+++ b/dynamo_query/dynamo_table.py
@@ -327,6 +327,8 @@ class DynamoTable(Generic[_RecordType], LazyLogger, ABC):
                 "ReadCapacityUnits": self.read_capacity_units,
                 "WriteCapacityUnits": self.write_capacity_units,
             }
+        else:
+            extra_params["BillingMode"] = "PAY_PER_REQUEST"
 
         return self.client.create_table(
             AttributeDefinitions=self._attribute_definitions,

--- a/tests/integration/test_dynamo_table.py
+++ b/tests/integration/test_dynamo_table.py
@@ -60,6 +60,23 @@ class TestDataTable:
     def setup_method(self):
         self.table.clear_table()
 
+    def test_create_pay_per_request(self):
+        class Cheap(DynamoTable):
+            "Use default 'pk' and 'sk' for keys."
+            @property
+            def table(self):
+                resource: DynamoDBServiceResource = boto3.resource(
+                    "dynamodb",
+                    endpoint_url="http://localhost:8000",
+                    region_name="us-west-1",
+                    aws_access_key_id="null",
+                    aws_secret_access_key="null",
+                )
+                return resource.Table("test_dq_cheap_table")  # pylint: disable=no-member
+
+        table = Cheap()
+        table.create_table()
+
     def test_clear_table(self):
         self.table.upsert_record(
             UserRecord(email="john_student@gmail.com", company="IBM", name="John", age=34)


### PR DESCRIPTION
## Notes

Defining a table where you do not specify read or write capacity, should create a table with 'pay per request' pricing.

## Public API changes

### Fixed

- Tables can now be created with "pay per request" billing mode if read_capacity_units or write_capacity_units are not set.
