### PR TITLE
Pass through consistent read flags for batch gets, and queries.

### DIFF
--- a/dynamo_query/base_dynamo_query.py
+++ b/dynamo_query/base_dynamo_query.py
@@ -91,6 +91,7 @@ class BaseDynamoQuery(LazyLogger):
         extra_params: Dict[str, Any],
         limit: int = MAX_LIMIT,
         exclusive_start_key: Optional[ExclusiveStartKey] = None,
+        consistent_read: bool = False,
         logger: logging.Logger = None,
     ):
         self._lazy_logger = logger
@@ -103,6 +104,7 @@ class BaseDynamoQuery(LazyLogger):
         self._raw_responses: List[Any] = []
         self._table_resource: Optional[Table] = None
         self._table_keys: Optional[TableKeys] = None
+        self._consistent_read = consistent_read
 
     def __str__(self) -> str:
         return f"<{self.__class__.__name__} type={self._query_type.value}>"
@@ -391,7 +393,7 @@ class BaseDynamoQuery(LazyLogger):
             for record in record_chunk:
                 key_data = {k: v for k, v in record.items() if k in self.table_keys}
                 key_data_list.append(key_data)
-            request_items = {table_name: {"Keys": key_data_list}}
+            request_items = {table_name: {"Keys": key_data_list, "ConsistentRead": self._consistent_read}}
             response = self._batch_get_item(
                 RequestItems=request_items,
                 **self._extra_params,

--- a/dynamo_query/dynamo_query_main.py
+++ b/dynamo_query/dynamo_query_main.py
@@ -433,14 +433,12 @@ class DynamoQuery(BaseDynamoQuery):
         Returns:
             `DynamoQuery` instance to execute.
         """
-        extra_params: Dict[str, Any] = dict(
-            ConsistentRead=consistent_read,
-            ReturnConsumedCapacity=return_consumed_capacity,
-        )
+        extra_params = dict(ReturnConsumedCapacity=return_consumed_capacity)
         return cls(
             query_type=QueryType.BATCH_GET_ITEM,
             expressions={},
             extra_params=extra_params,
+            consistent_read=consistent_read,
             logger=logger,
         )
 

--- a/dynamo_query/dynamo_query_main.py
+++ b/dynamo_query/dynamo_query_main.py
@@ -403,6 +403,7 @@ class DynamoQuery(BaseDynamoQuery):
     @classmethod
     def build_batch_get_item(
         cls: Type[_R],
+        consistent_read: bool = False,
         return_consumed_capacity: ReturnConsumedCapacityType = "NONE",
         logger: Optional[logging.Logger] = None,
     ) -> _R:
@@ -425,13 +426,17 @@ class DynamoQuery(BaseDynamoQuery):
         ```
 
         Arguments:
+            consistent_read -- `ConsistentRead` boto3 parameter.
             return_consumed_capacity -- `ReturnConsumedCapacity` value.
             logger -- `logging.Logger` instance.
 
         Returns:
             `DynamoQuery` instance to execute.
         """
-        extra_params = dict(ReturnConsumedCapacity=return_consumed_capacity)
+        extra_params: Dict[str, Any] = dict(
+            ConsistentRead=consistent_read,
+            ReturnConsumedCapacity=return_consumed_capacity,
+        )
         return cls(
             query_type=QueryType.BATCH_GET_ITEM,
             expressions={},


### PR DESCRIPTION
## Notes

We found ourselves wanting to be able to read after inserts, and ensure that we are having a consistent read experience.

Two primary uses cases for us were on the query and batch_get_records.

## Public API changes

### Changed

Added consistent_read flag to DynamoTable.batch_get, batch_get_records, and query.
Added consistent_read flag to DynamoQuery.build_batch_get_item.
