### PR TITLE
fix: upsert_record(condition_expression=)

### DIFF
--- a/dynamo_query/base_dynamo_query.py
+++ b/dynamo_query/base_dynamo_query.py
@@ -92,7 +92,7 @@ class BaseDynamoQuery(LazyLogger):
         limit: int = MAX_LIMIT,
         exclusive_start_key: Optional[ExclusiveStartKey] = None,
         consistent_read: bool = False,
-        logger: logging.Logger = None,
+        logger: Optional[logging.Logger] = None,
     ):
         self._lazy_logger = logger
         self._query_type = query_type
@@ -393,7 +393,9 @@ class BaseDynamoQuery(LazyLogger):
             for record in record_chunk:
                 key_data = {k: v for k, v in record.items() if k in self.table_keys}
                 key_data_list.append(key_data)
-            request_items = {table_name: {"Keys": key_data_list, "ConsistentRead": self._consistent_read}}
+            request_items = {
+                table_name: {"Keys": key_data_list, "ConsistentRead": self._consistent_read}
+            }
             response = self._batch_get_item(
                 RequestItems=request_items,
                 **self._extra_params,

--- a/tests/integration/test_dynamo_table.py
+++ b/tests/integration/test_dynamo_table.py
@@ -3,6 +3,8 @@ from typing import Dict, Optional
 import boto3
 import pytest
 
+from botocore import exceptions
+
 from dynamo_query.data_table import DataTable
 from dynamo_query.dictclasses.dynamo_dictclass import DynamoDictClass
 from dynamo_query.dynamo_table import DynamoTable
@@ -157,3 +159,31 @@ class TestDataTable:
             )
             == 0
         )
+
+    def test_upsert_record_condition_accept(self):
+        record = UserRecord(
+            email="john_student@gmail.com",
+            company="IBM",
+            name="John",
+            age=34,
+        )
+        self.table.upsert_record(
+            record,
+            ConditionExpression("email", "attribute_not_exists"),
+        )
+        assert len(list(self.table.scan())) == 1
+
+    def test_upsert_record_condition_reject(self):
+        record = UserRecord(
+            email="john_student@gmail.com",
+            company="IBM",
+            name="John",
+            age=34,
+        )
+        with pytest.raises(exceptions.ClientError) as err:
+            self.table.upsert_record(
+                record,
+                ConditionExpression("email", "attribute_exists"),
+            )
+        assert err.value.response["Error"]["Code"] == "ConditionalCheckFailedException"
+        assert len(list(self.table.scan())) == 0

--- a/tests/test_dynamo_query_main.py
+++ b/tests/test_dynamo_query_main.py
@@ -226,12 +226,16 @@ class TestDynamoQuery:
         assert list(result.get_records()) == []
 
         with pytest.raises(DynamoQueryError):
-            DynamoQuery.build_update_item(condition_expression=ConditionExpression("pk"),).table(
+            DynamoQuery.build_update_item(
+                condition_expression=ConditionExpression("pk"),
+            ).table(
                 table=table_resource_mock, table_keys=("pk", "sk")
             ).execute_dict({"pk": "value", "sk": "value", "test": "data"})
 
         with pytest.raises(DynamoQueryError):
-            DynamoQuery.build_update_item(condition_expression=ConditionExpression("pk"),).table(
+            DynamoQuery.build_update_item(
+                condition_expression=ConditionExpression("pk"),
+            ).table(
                 table=table_resource_mock, table_keys=("pk", "sk")
             ).update(add=["test"],).execute_dict({"pk": "value", "sk": "value", "test": "data"})
 
@@ -261,7 +265,12 @@ class TestDynamoQuery:
         )
         result = query.execute_dict({"pk": "value", "sk": "value"})
         table_resource_mock.meta.client.batch_get_item.assert_called_with(
-            RequestItems={table_resource_mock.name: {"Keys": [{"pk": "value", "sk": "value"}]}},
+            RequestItems={
+                table_resource_mock.name: {
+                    "Keys": [{"pk": "value", "sk": "value"}],
+                    "ConsistentRead": False,
+                }
+            },
             ReturnConsumedCapacity="NONE",
         )
         assert list(result.get_records()) == [{"pk": "value", "sk": "value"}]


### PR DESCRIPTION
## Notes

* (Narrowly) addresses the bug observed in https://github.com/altitudenetworks/dynamoquery/issues/70
  * doesn't attempt to convert the boto ClientError on condition reject
* The only actual _change_ is in `DynamoTable.upsert_record`, everything else is remedial:
  * Fixes tests broken since https://github.com/altitudenetworks/dynamoquery/pull/80
  * Fixes from black, isort, mypy

I feel like rolling a version update into this PR would be a bridge too far, but – assuming this fix is viable – it'd be most useful if it could go into a release fairly soon (see https://github.com/altitudenetworks/dynamoquery/issues/83 )

## Public API changes

### Changed

The `condition_expression` parameter to `DynamoTable.upsert_record` now takes values from `extra_data` to compose a `ConditionExpression` for the API call.
